### PR TITLE
fix(src/utils.ts): handle parsing non-quoted values in authenticate header

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,7 @@ assert.equal(
 
 # Authors
 - [Nicolas Froidure](https://insertafter.com/en/index.html)
+- undefined
 
 # License
 [MIT](https://github.com/nfroidure/http-auth-utils/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -680,7 +680,7 @@ assert.equal(
 
 # Authors
 - [Nicolas Froidure](https://insertafter.com/en/index.html)
-- undefined
+- [Jake Pruitt](https://github.com/jakepruitt)
 
 # License
 [MIT](https://github.com/nfroidure/http-auth-utils/blob/master/LICENSE)

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
       "jsarch"
     ]
   },
-  "contributors": [],
+  "contributors": ["Jake Pruitt <jake.pruitt@datadoghq.com>"],
   "files": [
     "dist",
     "src",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,11 @@
       "jsarch"
     ]
   },
-  "contributors": ["Jake Pruitt <jake.pruitt@datadoghq.com>"],
+  "contributors": [{
+    "name" : "Jake Pruitt",
+    "email" : "jake.pruitt@datadoghq.com",
+    "url" : "https://github.com/jakepruitt"
+  }],
   "files": [
     "dist",
     "src",

--- a/src/mechanisms/digest.test.ts
+++ b/src/mechanisms/digest.test.ts
@@ -26,6 +26,23 @@ describe('digest', () => {
         },
       );
     });
+
+    it('should handle non-quoted fields', () => {
+      neatequal(
+        DIGEST.parseWWWAuthenticateRest(
+          'realm="testrealm@host.com", ' +
+            'qop=auth, ' +
+            'algorithm=MD5, ' +
+            'nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093"',
+        ),
+        {
+          realm: 'testrealm@host.com',
+          qop: 'auth',
+          algorithm: 'MD5',
+          nonce: 'dcd98b7102dd2f0e8b11d0f600bfb0c093',
+        },
+      );
+    });
   });
 
   describe('buildWWWAuthenticateRest', () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -26,9 +26,35 @@ describe('utils', () => {
       );
     });
 
+    test('should work with parse-able non-quoted data', () => {
+      neatequal(
+        parseHTTPHeadersQuotedKeyValueSet(
+          'realm="testrealm@host.com", ' +
+            'qop=auth, ' +
+            'nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", ' +
+            'opaque="5ccc069c403ebaf9f0171e9517f40e41"',
+          ['realm', 'qop', 'nonce', 'opaque'],
+          ['realm', 'qop', 'nonce', 'opaque'],
+        ),
+        {
+          realm: 'testrealm@host.com',
+          qop: 'auth',
+          nonce: 'dcd98b7102dd2f0e8b11d0f600bfb0c093',
+          opaque: '5ccc069c403ebaf9f0171e9517f40e41',
+        },
+      );
+    });
+
     test('should fail with bad quoted value pair', () => {
       assert.throws(
         () => parseHTTPHeadersQuotedKeyValueSet('realm', []),
+        /E_MALFORMED_QUOTEDKEYVALUE/,
+      );
+    });
+
+    test('should fail with half-quoted value pair', () => {
+      assert.throws(
+        () => parseHTTPHeadersQuotedKeyValueSet('realm="uneven', ['realm']),
         /E_MALFORMED_QUOTEDKEYVALUE/,
       );
     });
@@ -40,11 +66,10 @@ describe('utils', () => {
       );
     });
 
-    test('should fail with bad quoted value pair', () => {
-      assert.throws(
-        () => parseHTTPHeadersQuotedKeyValueSet('realm=dsad', ['realm']),
-        /E_UNQUOTED_VALUE/,
-      );
+    test('should pass with non-quoted value pair', () => {
+      neatequal(parseHTTPHeadersQuotedKeyValueSet('realm=dsad', ['realm']), {
+        realm: 'dsad',
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #10 

### Proposed changes
- Uses a regular expression to parse the key-value pairs from the header string
- Uses a regular expression to remove the optional double-quotes
- Adds documentation for the regular expression
- Adds tests

### Code quality
- [x] I made some tests for my changes
- [x] I added my name in the
 [contributors](https://docs.npmjs.com/files/package.json#people-fields-author-contributors)
 field of the `package.json` file. Beware to use the same format than for the author field
 for the entries so that you'll get a mention in the `README.md` with a link to your website.

### License
To get your contribution merged, you must check the following.

- [x] I read the project license in the LICENSE file
- [x] I agree with publishing under this project license