### PR TITLE
fix(src/utils.ts): handle parsing values with equal signs

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -27,6 +27,25 @@ describe('utils', () => {
       );
     });
 
+    test('should work with equals in key values', () => {
+      neatequal(
+        parseHTTPHeadersQuotedKeyValueSet(
+          'realm="testrealm@host.com", ' +
+            'qop="auth, auth-int", ' +
+            'nonce="dGVzdCBzdHJpbmc=", ' +
+            'opaque="5ccc069c403ebaf9f0171e9517f40e41"',
+          ['realm', 'qop', 'nonce', 'opaque'],
+          ['realm', 'qop', 'nonce', 'opaque'],
+        ),
+        {
+          realm: 'testrealm@host.com',
+          qop: 'auth, auth-int',
+          nonce: 'dGVzdCBzdHJpbmc=',
+          opaque: '5ccc069c403ebaf9f0171e9517f40e41',
+        },
+      );
+    });
+
     test('should work with parse-able non-quoted data', () => {
       neatequal(
         parseHTTPHeadersQuotedKeyValueSet(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,17 +27,12 @@ export function parseHTTPHeadersQuotedKeyValueSet(
 
   const data = matches
     .map((part, partPosition) => {
-      const pair = part.split(EQUAL);
-
-      if (2 !== pair.length) {
-        throw new YError(
-          'E_MALFORMED_QUOTEDKEYVALUE',
-          partPosition,
-          part,
-          pair.length,
-        );
+      const [key, ...rest] = part.split(EQUAL);
+      const value = rest.join(EQUAL);
+      if (0 === rest.length) {
+        throw new YError('E_MALFORMED_QUOTEDKEYVALUE', partPosition, part);
       }
-      return pair;
+      return [key, value];
     })
     .reduce(function (parsedValues, [name, value], valuePosition) {
       if (-1 === authorizedKeys.indexOf(name)) {


### PR DESCRIPTION
Fixes #17

### Proposed changes
- As said in [this comment](https://github.com/nfroidure/http-auth-utils/pull/18#discussion_r957029361), the solution should look like `[pair[0], pair.slice(1).join('=')]`. This PR does something like that.
- The error check (for `E_MALFORMED_QUOTEDKEYVALUE`) is also updated.

<!-- Check the boxes with a `x` like so `[x]` -->

### Code quality
- [x] I made some tests for my changes
- [ ] I added my name in the [contributors](https://docs.npmjs.com/files/package.json#people-fields-author-contributors) field of the `package.json` file. Beware to use the same format than for the author field for the entries so that you'll get a mention in the `README.md` with a link to your website.

### License
To get your contribution merged, you must check the following.

- [x] I read the project license in the LICENSE file
- [x] I agree with publishing under this project license